### PR TITLE
fix(ios): restore gesture passthrough in iOS 18 using improved hitTest override

### DIFF
--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -33,7 +33,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NitroToast (1.0.2):
+  - NitroToast (1.0.3):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -2076,7 +2076,7 @@ SPEC CHECKSUMS:
   glog: 5683914934d5b6e4240e497e0f4a3b42d1854183
   hermes-engine: 314be5250afa5692b57b4dd1705959e1973a8ebe
   NitroModules: 4e92fa5218beff179daf51714fd117e829027dd3
-  NitroToast: b7f4f963c867ccb9b6b403ccd2881d9ff7ff3dcd
+  NitroToast: fdb7ffbb7c4a6dc8f44601d2c142d6a8bc09acfb
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
   RCTDeprecation: 83ffb90c23ee5cea353bd32008a7bca100908f8c
   RCTRequired: eb7c0aba998009f47a540bec9e9d69a54f68136e

--- a/ios/NativeIntegration/PassthroughView.swift
+++ b/ios/NativeIntegration/PassthroughView.swift
@@ -14,9 +14,45 @@ import UIKit
 ///
 /// Helps ensure touch events work correctly when integrating with React Native.
 class PassthroughWindow: UIWindow {
+  override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
+    if #available(iOS 18, *) {
+      guard let root = rootViewController?.view else { return false }
+      let hit = Self._hitTest(point, with: event, in: subviews.count > 1 ? self : root)
+      return hit != nil
+    }
+    return super.point(inside: point, with: event)
+  }
   override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-    let hitView = super.hitTest(point, with: event)
-    // Let touches pass through if it's not on a visible toast
-    return hitView == self.rootViewController?.view ? nil : hitView
+    if #available(iOS 18, *) {
+      return super.hitTest(point, with: event)
+    }
+    let hit = super.hitTest(point, with: event)
+    return (hit == rootViewController?.view) ? nil : hit
+  }
+  private static func _hitTest(
+    _ point: CGPoint,
+    with event: UIEvent?,
+    in view: UIView,
+    depth: Int = 0
+  ) -> (view: UIView, depth: Int)? {
+    var best: (view: UIView, depth: Int)?
+    for sub in view.subviews.reversed() {
+      let pt = view.convert(point, to: sub)
+      guard sub.isUserInteractionEnabled, !sub.isHidden, sub.alpha > 0,
+            sub.point(inside: pt, with: event) else { continue }
+      if let deeper = _hitTest(pt, with: event, in: sub, depth: depth + 1) {
+        if best == nil || deeper.depth > best!.depth { best = deeper }
+      } else {
+        if best == nil || depth > best!.depth { best = (sub, depth) }
+      }
+    }
+    return best
   }
 }
+
+
+
+
+
+
+


### PR DESCRIPTION
Closes #2 