### PR TITLE
fix(ios/Toast): use `.primary` as fallback instead of hardcoded black

### DIFF
--- a/ios/Model/Toast.swift
+++ b/ios/Model/Toast.swift
@@ -119,7 +119,7 @@ extension Toast {
         if let hex = config.titleColor {
             return Color(hex)
         }
-        return .black
+        return .primary
     }
 
     var messageColor: Color {


### PR DESCRIPTION
Title is not visible in dark mode. Use dynamic `.primary` color instead of hardcoded `.black` to ensure visibility across both theme modes.