### PR TITLE
docs: add architecture overview and v2 roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -79,3 +79,7 @@ lib/
 
 # Claude Code personal workflow (skills, MCP settings, permissions)
 .claude/
+
+# v2 planning working docs (maintainer-only; ROADMAP.md stays tracked)
+docs/v2/IMPLEMENTATION.md
+docs/v2/plans/

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,221 @@
+# Architecture Overview
+
+`react-native-nitro-toast` is a lightweight, native-powered toast notification
+library for React Native, built on **[Nitro Modules](https://nitro.margelo.com)**.
+The UI is rendered with **SwiftUI on iOS** and **Jetpack Compose on Android** —
+there is no legacy bridge serialization; calls cross into native code via JSI
+through the Nitro abstraction layer.
+
+This document explains how the pieces fit together. For day-to-day usage see the
+[README](./README.md); for contributor workflows and commands see [CLAUDE.md](./CLAUDE.md).
+
+---
+
+## High-level picture
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  JavaScript / TypeScript (your app)                            │
+│                                                                │
+│   showToast() · dismissToast() · showToastPromise()            │
+│                         │                                      │
+│        src/index.ts  ───┘  (public API + default config)       │
+│                         │                                      │
+│   NitroModules.createHybridObject<NitroToast>('NitroToast')    │
+└─────────────────────────┬──────────────────────────────────── ┘
+                          │  JSI (zero bridge overhead)
+            ┌─────────────┴─────────────┐
+            ▼                           ▼
+┌────────────────────────┐   ┌────────────────────────┐
+│  iOS (Swift + SwiftUI) │   │ Android (Kotlin/Compose)│
+│                        │   │                         │
+│  HybridNitroToast      │   │  HybridNitroToast       │
+│        │               │   │        │                │
+│  ToastViewModel        │   │  ToastManager           │
+│   (UIWindow owner)     │   │  (decorView overlay)    │
+│        │               │   │        │                │
+│  SwiftUI Toast views   │   │  Compose Toast views    │
+└────────────────────────┘   └────────────────────────┘
+```
+
+The library is intentionally split into three layers that **must stay in sync**:
+
+```
+src/specs/NitroToast.nitro.ts   ← TypeScript interface (the source of truth)
+        │  bun run specs  (tsc + nitro-codegen)
+        ▼
+nitrogen/                        ← auto-generated C++/Swift/Kotlin bridge  (DO NOT edit)
+        ▼
+ios/.../HybridNitroToast.swift   ← iOS implementation
+android/.../HybridNitroToast.kt  ← Android implementation
+```
+
+If you change the native-facing interface (`show` / `dismiss` / `NitroToastConfig`),
+you must regenerate `nitrogen/` and update **both** native implementations.
+
+---
+
+## The contract: `NitroToast.nitro.ts`
+
+Everything starts from a single Nitro `HybridObject` interface in
+[`src/specs/NitroToast.nitro.ts`](./src/specs/NitroToast.nitro.ts):
+
+```ts
+export interface NitroToast extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
+  show(message: string, config: NitroToastConfig): string  // returns toastId
+  dismiss(toastId: string): void
+}
+```
+
+The surface is deliberately tiny — just two methods. All visual/behavioral
+configuration is carried in the `NitroToastConfig` value object (type, presentation,
+duration, position, colors, overlay, haptics, custom icon, font family). Keeping the
+method count small means the native bridge rarely needs regeneration; most feature
+work is additive fields on the config object.
+
+`nitro.json` ties this interface to the native classes via autolinking:
+both platforms register a class literally named `HybridNitroToast`, under the
+`NitroToast` module / `nitrotoast` C++ namespace.
+
+---
+
+## TypeScript layer (`src/`)
+
+| File | Role |
+|------|------|
+| [`src/specs/NitroToast.nitro.ts`](./src/specs/NitroToast.nitro.ts) | The Nitro interface + `NitroToastConfig` — the source of truth |
+| [`src/index.ts`](./src/index.ts) | Public API barrel: `showToast`, `dismissToast`, `showToastPromise`, `defaultToastConfig` |
+| [`src/types.ts`](./src/types.ts) | Helper types for the promise API (`ToastPromiseMessages`, `ToastPromiseConfig`) |
+
+The public API is a thin ergonomic wrapper over the raw Nitro object:
+
+- **`showToast(message, config?)`** merges the caller's partial config over
+  `defaultToastConfig`, applies one smart default (a `loading` toast defaults to
+  `duration: 0` so it never auto-dismisses), then calls into native and returns the
+  toast id.
+- **`dismissToast(id)`** forwards straight to the native `dismiss`.
+- **`showToastPromise(promise, messages, config)`** shows a `loading` toast, awaits
+  the promise, then **reuses the same `toastId`** to morph it into a `success` or
+  `error` toast — so the user sees one toast transition states rather than three
+  separate toasts.
+
+`src/index.ts` is the **only** public export barrel. Internal helpers must not be
+re-exported unless intentional, and all public exports carry explicit types.
+
+---
+
+## iOS layer (`ios/`)
+
+| File | Role |
+|------|------|
+| `NativeIntegration/HybridNitroToast.swift` | Nitro entry point; hops to the main thread |
+| `ViewModels/ToastViewModel.swift` | `@MainActor` singleton; owns the `UIWindow` and `[Toast]` state |
+| `NativeIntegration/PassthroughView.swift` | `UIWindow` subclass that lets touches fall through to the app |
+| `Views/ToastListView.swift` | Alert-mode SwiftUI rendering |
+| `Views/ToastStackView.swift` | Stacked-mode SwiftUI rendering |
+| `Views/ToastIconView.swift` | Icon renderer (predefined types + custom `iconUri`) |
+| `Model/Toast.swift` | `Toast` model (`ObservableObject`) |
+| `Helpers/Color+Extensions.swift` | Hex string → SwiftUI `Color` |
+
+**Runtime flow:**
+
+1. `HybridNitroToast.show()` is called from the JS thread. It resolves a `toastId`
+   (caller-provided or a fresh `UUID`) and immediately returns it, dispatching the
+   real work to `DispatchQueue.main`.
+2. `ToastViewModel.shared.present()` runs on the main actor. If no toast window
+   exists yet, it lazily creates a `PassthroughWindow` at `windowLevel: .alert + 1`
+   and hosts a SwiftUI view in it — so toasts float above the entire app, including
+   modals, without blocking touches.
+3. The view model appends to its `@Published var toasts` array and starts an async
+   countdown task for auto-dismiss.
+4. On dismiss (timeout or explicit `dismiss(toastId:)`), the toast is removed from
+   the array; when the array becomes empty the `UIWindow` is torn down so nothing
+   lingers.
+
+Because the id is returned synchronously before the UI work runs, the JS
+`showToastPromise` flow can reliably target the same toast across state changes.
+
+---
+
+## Android layer (`android/.../nitrotoast/`)
+
+| File | Role |
+|------|------|
+| `HybridNitroToast.kt` | Nitro entry point; delegates to `ToastManager` |
+| `ToastManager.kt` | `object` singleton; owns the `ComposeView` overlay and coroutine lifecycle |
+| `ToastList.kt` | Compose rendering (alert + stacked modes) |
+| `ToastView.kt` | Individual toast composable |
+| `ToastIcon.kt` | Icon composable |
+| `DraggableToast.kt` | Swipe-to-dismiss gesture wrapper |
+| `Toast.kt` | Data class |
+| `Utils.kt` | Hex → `Color` and other helpers |
+
+**Runtime flow:**
+
+1. `HybridNitroToast.show()` is called on the Nitro thread. It resolves a `toastId`
+   (caller-provided or a fresh `UUID`), then grabs the current `Activity` from
+   `NitroModules.applicationContext` and delegates to `ToastManager.show(...)`.
+2. `ToastManager.ensureToastContainer()` attaches a `ComposeView` to the activity's
+   `window.decorView` if one isn't already present — this is the overlay surface that
+   hosts all toasts.
+3. A coroutine runs `handleToastLifecycle()`: it waits one frame (~16ms) before
+   marking the toast visible (so the enter animation runs), then auto-dismisses after
+   the configured duration.
+4. On dismiss, `removeWithAnimation()` animates the toast out and removes it from
+   state; when the list is empty the `ComposeView` container is detached from
+   `decorView`.
+
+State is held in a `MutableStateFlow`-backed list inside `ToastManager`, which the
+Compose tree observes — the Kotlin analogue of iOS's `@Published` array.
+
+---
+
+## Cross-platform symmetry
+
+Both platforms follow the same shape, which makes the codebase easy to reason about:
+
+| Concern | iOS | Android |
+|---------|-----|---------|
+| Entry point | `HybridNitroToast` (Swift) | `HybridNitroToast` (Kotlin) |
+| Singleton state owner | `ToastViewModel.shared` | `object ToastManager` |
+| Overlay surface | dedicated `PassthroughWindow` | `ComposeView` on `decorView` |
+| Reactive state | `@Published var toasts` | `MutableStateFlow` |
+| Threading | `DispatchQueue.main` / `@MainActor` | `runOnUiThread` / `Dispatchers.Main` |
+| Auto-dismiss | async countdown task | coroutine lifecycle |
+| Touch passthrough | `PassthroughView` window | overlay added without intercepting input |
+
+`toastId` is the shared currency across both layers and both platforms: it's how a
+toast is updated in place (e.g. loading → success) and how it's explicitly dismissed.
+
+---
+
+## Codegen (`nitrogen/`) — do not edit
+
+`bun run specs` runs `tsc` then `nitro-codegen`, regenerating the `nitrogen/`
+directory: the C++ JSI bridge, Swift specs (`HybridNitroToastSpec`), and Kotlin specs
+(`HybridNitroToastSpec`). The native implementations subclass/conform to these
+generated specs. **Never edit `nitrogen/` by hand** — changes are overwritten on the
+next codegen run. Regenerate whenever `nitro.json` or any `*.nitro.ts` file changes.
+
+---
+
+## Build & distribution
+
+- `bun run prepare` builds `src/` → `lib/` via `react-native-builder-bob`. `lib/` is
+  build output — never edit it directly.
+- iOS is consumed as a CocoaPod via `NitroToast.podspec`; Android as a Gradle module
+  (`android/build.gradle`, `CMakeLists.txt`).
+- The `example/` app is the living integration test and demo surface; it should be
+  updated whenever observable behavior changes.
+
+---
+
+## Adding a feature — the mental model
+
+1. **Additive config field?** Add it to `NitroToastConfig` in the `.nitro.ts` file,
+   run `bun run specs`, then read it in both `ToastViewModel` (iOS) and `ToastManager`
+   / Compose views (Android). No new method needed → minimal bridge churn.
+2. **New method on the interface?** Edit `.nitro.ts`, regenerate, implement in both
+   `HybridNitroToast.swift` and `HybridNitroToast.kt`. Both platforms must compile.
+3. **JS-only ergonomics?** (e.g. another promise helper) Add to `src/index.ts` /
+   `src/types.ts` — no codegen required.

--- a/docs/v2/ROADMAP.md
+++ b/docs/v2/ROADMAP.md
@@ -1,0 +1,164 @@
+# react-native-nitro-toast — v2 Roadmap
+
+> Status: **Planning**
+> This document is the high-level map for v2. Each item links to a detailed
+> implementation plan under [`./plans/`](./plans/) (created when the item is picked up).
+> Use [`./plans/_TEMPLATE.md`](./plans/_TEMPLATE.md) as the starting point for a new plan.
+
+For the current design see [ARCHITECTURE.md](../../ARCHITECTURE.md).
+**To start building, follow the ordered playbook → [IMPLEMENTATION.md](./IMPLEMENTATION.md).**
+
+---
+
+## Scope decision (locked)
+
+v2 stays a **focused, single-purpose toast library** — do one thing extremely well.
+**Out of scope (decided):** alert / dialog / confirm subsystems. The passthrough,
+non-blocking interaction model of a toast is the opposite of a modal alert; mixing
+them would dilute the library. Use a dedicated dialog library for that need.
+
+`show()` keeps its **upsert** behavior (same `toastId` → update in place). This is the
+established, familiar API and will not be split into a separate `update()`.
+
+## Goals for v2
+
+1. **Performance first** — make the single toast pipeline excellent: kill the timer
+   busy-loop, tighten the lifecycle, zero wasted wakeups/leaks.
+2. **First-class iPad & Android tablet** — adaptive layout for large/regular size
+   classes and multi-window.
+3. Pay down **timer / lifecycle** tech debt that differs across platforms.
+4. Add **CI + tests** so v2 ships with confidence.
+5. Keep the native-bridge surface small — batch any interface changes into a single
+   codegen round.
+
+Legend: 🔴 breaking · 🟢 non-breaking · ⚙️ infra · effort `S`/`M`/`L`
+
+---
+
+## Workstream 1 — Optimizations (tech debt)
+
+Grounded in current code; most are **non-breaking** and can ship in v1.x before v2.
+
+| # | Item | Where | Tag | Effort | Plan |
+|---|------|-------|-----|--------|------|
+| O1 | Replace 10 Hz countdown busy-loop with deadline + pause/resume model | [ToastViewModel.swift:42](../../ios/ViewModels/ToastViewModel.swift#L42), [ToastManager.kt:182](../../android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt#L182) | 🟢 | M | _tbd_ |
+| O2 | iOS: store & cancel countdown task on dismiss/update (match Android) | [ToastViewModel.swift:42](../../ios/ViewModels/ToastViewModel.swift#L42) | 🟢 | S | _tbd_ |
+| O3 | Android: reuse `scope` in `checkAndRemoveContainer` (no orphan scope) | [ToastManager.kt:205](../../android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt#L205) | 🟢 | S | _tbd_ |
+| O4 | Verify & fix pause-on-hold parity (Android lifecycle ignores `pauseMap`) | [ToastManager.kt:193](../../android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt#L193) | 🟢 | S | _tbd_ |
+| O5 | Remove leftover `Log.d` in production path | [ToastManager.kt:188](../../android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt#L188) | 🟢 | XS | _tbd_ |
+| O6 | iOS: derive window frame from `windowScene` (multi-window / rotation safe) — **prerequisite for iPad (T1)** | [ToastViewModel.swift:82](../../ios/ViewModels/ToastViewModel.swift#L82) | 🟢 | S | _tbd_ |
+| O7 | Extract animation-offset magic number (`-300`/`0.3s`) into a named constant | both | 🟢 | XS | _tbd_ |
+
+---
+
+## Workstream 2 — Features
+
+### 2a. Interface-changing (require `bun run specs` + impl on both platforms)
+
+> Batch these into **one** codegen round to minimize bridge churn.
+
+| # | Feature | Tag | Effort | Notes | Plan |
+|---|---------|-----|--------|-------|------|
+| F1 | Callbacks: `onPress`, `onShow`, `onDismiss`, `onAutoClose` | 🔴 | L | Nitro supports passing functions in config | _tbd_ |
+| F2 | Action button (label + callback), e.g. "Undo" / "Retry" | 🔴 | L | Builds on F1 | _tbd_ |
+| F3 | Progress bar countdown indicator | 🟢 | M | Visual duration bar | _tbd_ |
+
+### 2b. Additive API (low risk — new method or optional field)
+
+| # | Feature | Tag | Effort | Notes | Plan |
+|---|---------|-----|--------|-------|------|
+| F4 | `dismissAll()` | 🟢 | S | Currently only dismiss-by-id | _tbd_ |
+| P1 | **Android stacked-mode parity** (collapsed deck + expand-on-tap) | 🟢 | M | Today Android ignores `presentation` and always renders a plain vertical `Column` ([ToastList.kt:32](../../android/src/main/java/com/margelo/nitro/nitrotoast/ToastList.kt#L32)); the iOS deck/expand behavior ([ToastStackView.swift](../../ios/Views/ToastStackView.swift)) is iOS-only. No interface change (the `'stacked'` value already exists). See notes below | _tbd_ |
+| F6 | Global `configure(defaults)` for app-wide defaults | 🟢 | M | `defaultToastConfig` is exported but not settable | _tbd_ |
+| F7 | `maxToasts` cap for stacked mode | 🟢 | S | Prevent unbounded growth | _tbd_ |
+| F8 | Offset / inset config (custom top/bottom margin) | 🟢 | S | | _tbd_ |
+
+#### P1 — Android stacked-mode parity: implementation notes
+
+Additive native work, no Nitro bridge / codegen change. Reuses existing infra
+(`ToastListState` StateFlow, [DraggableToast.kt](../../android/src/main/java/com/margelo/nitro/nitrotoast/DraggableToast.kt)).
+
+1. Add `isExpanded: MutableStateFlow<Boolean>` to `ToastListState`.
+2. Branch on `config.presentation` in `toastList` (mirror iOS `makeToastView`): `alert` → current vertical column; `stacked` → new `stackedToastList`.
+3. `stackedToastList`: render a `Box` deck; per-toast `Modifier.graphicsLayer { scaleX/Y; translationY }` by index, animated via `animateFloatAsState`/`animateDpAsState`; tap toggles `isExpanded` (collapsed deck ↔ vertical list morph).
+
+**iOS → Compose mapping & the one caveat:**
+
+| iOS technique | Compose equivalent |
+|---|---|
+| `AnyLayout` (16+) / `matchedGeometryEffect` (15) morph | per-property `animate*AsState` on offset+scale, or `LookaheadScope` + shared-element |
+| deck scale + `offsetY` by index | `graphicsLayer { scaleX/Y; translationY }` |
+| tap-to-expand `isExpanded` | `MutableStateFlow<Boolean>` |
+| swipe-to-dismiss | existing `DraggableToast` |
+| `.ultraThinMaterial` backdrop | **blur only on API 31+** (`Modifier.blur`); fallback to a dim scrim below 31 |
+
+> ⚠️ The true material blur backdrop is the only non-1:1 part: real blur requires
+> Android 12 (API 31). Use a semi-transparent scrim as the fallback.
+
+### 2c. Differentiators
+
+| # | Feature | Tag | Effort | Notes | Plan |
+|---|---------|-----|--------|-------|------|
+| F9 | Accessibility: VoiceOver / TalkBack announcements + label | 🟢 | M | Likely missing today; high value | _tbd_ |
+| F10 | Dark-mode aware default colors | 🟢 | M | Follow system color scheme | _tbd_ |
+| F11 | Animation config (enter/exit type & duration) | 🟢 | M | | _tbd_ |
+| F12 | RTL support | 🟢 | S | | _tbd_ |
+
+> **Deferred (post-v2):** custom JSX content via Nitro HybridView. Large surface that
+> conflicts with v2's focused-performance scope; README already points users to a JS
+> lib for full layout customization. Revisit only after the perf + tablet goals land.
+
+---
+
+## Workstream 2d — Tablet & iPad (adaptive layout) 📱
+
+The headline platform goal for v2: toasts should look right on large screens, not just
+stretch edge-to-edge. Drives layout work across both platforms and is gated on the iOS
+scene fix (O6).
+
+| # | Item | Tag | Effort | Notes | Plan |
+|---|------|-----|--------|-------|------|
+| T1 | iOS iPad: max-width + horizontal centering on regular size class | 🟢 | M | Depends on O6 (windowScene). Avoid full-width stretch | _tbd_ |
+| T2 | iOS iPad multi-window / Stage Manager: host toast in the active scene | 🟢 | M | Builds on O6 | _tbd_ |
+| T3 | Android tablet: max-width + centering on large `WindowSizeClass` | 🟢 | M | Use `WindowMetrics` / size class | _tbd_ |
+| T4 | Orientation change: keep position correct on rotate (both) | 🟢 | S | Re-evaluate frame/insets on config change | _tbd_ |
+| T5 | Optional `maxWidth` config field for explicit control | 🟢 | S | Lets apps tune large-screen width | _tbd_ |
+
+---
+
+## Workstream 3 — Infra & quality ⚙️
+
+Findings from the infra audit (2026-06-02). Priorities: **I4 + I1 first** (correctness/safety), then the rest.
+
+| # | Item | Priority | Effort | Notes | Plan |
+|---|------|----------|--------|-------|------|
+| I1 | CI workflow: typecheck + lint + native build on every PR | 🔴 | M | No PR CI today — only `release.yml` on tag push | _tbd_ |
+| I2 | Unit tests for JS layer (`showToastPromise`, config merge, loading-duration default) | 🟡 | M | | _tbd_ |
+| I3 | RN version / New Architecture compatibility matrix in docs | 🟢 | S | | _tbd_ |
+| I4 | Remove `postinstall: "tsc \|\| exit 0"` — it runs `tsc` in **consumers'** node_modules | 🔴 | XS | [package.json:34](../../package.json#L34); build is already handled by `prepare` (bob) | _tbd_ |
+| I5 | Harden release pipeline: explicit `bun run prepare` + typecheck + lint + test gate before publish; don't rely implicitly on the `prepare` lifecycle | 🔴 | S | [release.yml](../../.github/workflows/release.yml) currently does only `bun install` → `npm-publish` | _tbd_ |
+| I6 | Fix `package.json` metadata: remove non-existent `app.plugin.js` from `files`; verify/fix `specs` script (`typescript &&` likely not a valid bin → `tsc &&`) | 🟡 | XS | [package.json:29](../../package.json#L29), [package.json:41](../../package.json#L41) | _tbd_ |
+| I7 | Tighten `peerDependencies` (`react`/`react-native` are `"*"`) to a supported range | 🟡 | XS | [package.json:81](../../package.json#L81) | _tbd_ |
+| I8 | Release hygiene & nice-to-haves: `requireCleanWorkingDir: true`, bump `checkout@v4`/`setup-bun@v2`, `--frozen-lockfile`, `engines` field, npm `--provenance`, Android Java 17 | 🟢 | S | [.release-it.json:6](../../.release-it.json#L6), [release.yml](../../.github/workflows/release.yml), [build.gradle:113](../../android/build.gradle#L113) | _tbd_ |
+
+---
+
+## Proposed release sequencing
+
+Priorities, in order: **(1) performance** → **(2) tablet/iPad** → everything else.
+
+- **v1.x (non-breaking, ship incrementally):** I4 + I1 (infra safety, do first), O1–O7 (perf/lifecycle), F4, F7, I2, I5, I6.
+- **v2.0 (tablet/iPad headline + parity):** T1–T5 + O6, **P1 (Android stacked parity)**, plus additive niceties F6, F8.
+- **v2.x:** interaction (F1, F2), F3, F9–F12, I3.
+
+> Custom JSX content (deferred) and any alert/dialog work (out of scope) are intentionally
+> absent — see the **Scope decision** at the top.
+
+---
+
+## How to use this folder
+
+1. Pick an item above.
+2. Copy [`./plans/_TEMPLATE.md`](./plans/_TEMPLATE.md) → `./plans/<id>-<slug>.md` (e.g. `F1-callbacks.md`).
+3. Fill in the plan, then link it back in the table's **Plan** column.
+4. Implement following the [Nitro Interface Change Workflow](../../CLAUDE.md) and Quality Gates in `CLAUDE.md`.


### PR DESCRIPTION
- ARCHITECTURE.md: three-layer Nitro design + iOS/Android runtime flow
- docs/v2/ROADMAP.md: v2 plan (perf, tablet/iPad, parity, infra)