### PR TITLE
perf: rework toast auto-dismiss lifecycle (timer, pause parity, cancellation)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
@@ -5,6 +5,7 @@ import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.os.Build
+import android.os.SystemClock
 import android.os.VibrationEffect
 import android.os.Vibrator
 import android.view.ViewGroup
@@ -17,7 +18,9 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withTimeoutOrNull
 
 /** Duration of the toast enter/exit and update animations, in milliseconds. */
 private const val ANIMATION_DURATION_MS = 300L
@@ -190,12 +193,20 @@ object ToastManager {
 
         if (duration > 0) {
             var remaining = duration.toLong() - ANIMATION_DURATION_MS
-            val interval = 100L
             while (remaining > 0) {
-                delay(interval)
-                // Honor hold-to-pause: only count down while not paused (matches iOS).
-                if (state.pauseMap.value[toast.id] != true) {
-                    remaining -= interval
+                // Suspend (no polling) until the toast is not paused.
+                state.pauseMap.first { it[toast.id] != true }
+                val start = SystemClock.elapsedRealtime()
+                // Sleep for the remaining time, waking early only if it becomes paused.
+                val becamePaused =
+                    withTimeoutOrNull(remaining) {
+                        state.pauseMap.first { it[toast.id] == true }
+                        true
+                    }
+                if (becamePaused == null) {
+                    remaining = 0
+                } else {
+                    remaining -= SystemClock.elapsedRealtime() - start
                 }
             }
             state.removeWithAnimation(toast.id)

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.os.Build
 import android.os.VibrationEffect
 import android.os.Vibrator
-import android.util.Log
 import android.view.ViewGroup
 import androidx.annotation.RequiresPermission
 import androidx.compose.ui.platform.ComposeView
@@ -19,6 +18,9 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
+
+/** Duration of the toast enter/exit and update animations, in milliseconds. */
+private const val ANIMATION_DURATION_MS = 300L
 
 class ToastListState {
     private val _toasts = MutableStateFlow(emptyList<Toast>())
@@ -74,7 +76,7 @@ class ToastListState {
 
     suspend fun removeWithAnimation(toastId: String) {
         updateVisibility(toastId, false)
-        delay(300)
+        delay(ANIMATION_DURATION_MS)
         _toasts.value = _toasts.value.filterNot { it.id == toastId }
     }
 }
@@ -121,7 +123,7 @@ object ToastManager {
         state.updateToast(toastId, message, config)
         state.setUpdating(toastId, true)
         scope.launch {
-            delay(300)
+            delay(ANIMATION_DURATION_MS)
             state.setUpdating(toastId, false)
         }
         lifecycleJobs[toastId]?.cancel()
@@ -185,10 +187,9 @@ object ToastManager {
     ) {
         delay(16)
         state.updateVisibility(toast.id, true)
-        Log.d("ToastManager", "Showing toast: $toast")
 
         if (duration > 0) {
-            var remaining = duration.toLong() - 300
+            var remaining = duration.toLong() - ANIMATION_DURATION_MS
             val interval = 100L
             while (remaining > 0) {
                 delay(interval)
@@ -203,7 +204,7 @@ object ToastManager {
     private fun checkAndRemoveContainer() {
         val context = toastContainer?.context as? Activity ?: return
         CoroutineScope(Dispatchers.Main).launch {
-            delay(300)
+            delay(ANIMATION_DURATION_MS)
             if (state.toasts.value.isEmpty()) {
                 (context.window?.decorView as? ViewGroup)?.removeView(toastContainer)
                 toastContainer = null

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
@@ -203,7 +203,7 @@ object ToastManager {
 
     private fun checkAndRemoveContainer() {
         val context = toastContainer?.context as? Activity ?: return
-        CoroutineScope(Dispatchers.Main).launch {
+        scope.launch {
             delay(ANIMATION_DURATION_MS)
             if (state.toasts.value.isEmpty()) {
                 (context.window?.decorView as? ViewGroup)?.removeView(toastContainer)

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
@@ -193,7 +193,10 @@ object ToastManager {
             val interval = 100L
             while (remaining > 0) {
                 delay(interval)
-                remaining -= interval
+                // Honor hold-to-pause: only count down while not paused (matches iOS).
+                if (state.pauseMap.value[toast.id] != true) {
+                    remaining -= interval
+                }
             }
             state.removeWithAnimation(toast.id)
         }

--- a/ios/ViewModels/ToastViewModel.swift
+++ b/ios/ViewModels/ToastViewModel.swift
@@ -15,6 +15,10 @@ class ToastViewModel: ObservableObject {
     /// Duration of the toast enter/exit and update animations.
     private static let animationDuration: TimeInterval = 0.3
 
+    /// Per-toast auto-dismiss countdown tasks, so they can be cancelled on
+    /// dismiss/update instead of running to completion.
+    private var countdownTasks: [String: Task<Void, Never>] = [:]
+
     var toastWindow: UIWindow?
 
     var isEmpty: Bool { toasts.isEmpty }
@@ -41,14 +45,21 @@ class ToastViewModel: ObservableObject {
             triggerHaptics(for: config.type)
         }
 
-        guard config.duration > 0 else { return }
+        // Cancel any in-flight countdown for this toast (e.g. on update).
+        countdownTasks[toast.id]?.cancel()
 
-        Task {
+        guard config.duration > 0 else {
+            countdownTasks[toast.id] = nil
+            return
+        }
+
+        countdownTasks[toast.id] = Task {
             var remaining = config.duration / 1000
             let interval: TimeInterval = 0.1
 
             while remaining > 0 {
                 try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+                if Task.isCancelled { return }
                 if !self.isExpanded && !toast.isPaused {
                     remaining -= interval
                 }
@@ -97,6 +108,8 @@ class ToastViewModel: ObservableObject {
 
     func dismiss(_ toastId: String) {
         guard let index = toasts.firstIndex(where: { $0.id == toastId }) else { return }
+        countdownTasks[toastId]?.cancel()
+        countdownTasks[toastId] = nil
         toasts[index].isDeleting = true
 
         withAnimation(.bouncy) {

--- a/ios/ViewModels/ToastViewModel.swift
+++ b/ios/ViewModels/ToastViewModel.swift
@@ -53,19 +53,66 @@ class ToastViewModel: ObservableObject {
             return
         }
 
-        countdownTasks[toast.id] = Task {
+        countdownTasks[toast.id] = Task { [weak self] in
+            guard let self else { return }
             var remaining = config.duration / 1000
-            let interval: TimeInterval = 0.1
+            let paused = self.pausedStream(for: toast)
 
             while remaining > 0 {
-                try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
                 if Task.isCancelled { return }
-                if !self.isExpanded && !toast.isPaused {
-                    remaining -= interval
+
+                // Suspend (no polling) until the toast is not paused. CombineLatest
+                // emits the current value immediately, so this returns at once if
+                // the toast is already active.
+                for await isPaused in paused.values {
+                    if Task.isCancelled { return }
+                    if !isPaused { break }
+                }
+
+                let start = Date()
+                // Sleep for the remaining time, waking early if it becomes paused.
+                let interrupted = await Self.sleep(remaining, interruptedBy: paused)
+                if Task.isCancelled { return }
+                if interrupted {
+                    remaining -= Date().timeIntervalSince(start)
+                } else {
+                    remaining = 0
                 }
             }
 
             self.dismiss(toast.id)
+        }
+    }
+
+    /// A stream of the "effective paused" state for a toast: paused while the
+    /// stack is expanded or the toast is being held. Emits on every change.
+    private func pausedStream(for toast: Toast) -> AnyPublisher<Bool, Never> {
+        Publishers.CombineLatest($isExpanded, toast.$isPaused)
+            .map { expanded, paused in expanded || paused }
+            .removeDuplicates()
+            .eraseToAnyPublisher()
+    }
+
+    /// Sleeps for `seconds`, returning `false` if the full time elapsed, or
+    /// `true` if `pausedStream` reported a paused state first.
+    private static func sleep(
+        _ seconds: TimeInterval,
+        interruptedBy pausedStream: AnyPublisher<Bool, Never>
+    ) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                return false
+            }
+            group.addTask {
+                for await isPaused in pausedStream.values where isPaused {
+                    return true
+                }
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
         }
     }
 

--- a/ios/ViewModels/ToastViewModel.swift
+++ b/ios/ViewModels/ToastViewModel.swift
@@ -11,6 +11,10 @@ import SwiftUI
 @MainActor
 class ToastViewModel: ObservableObject {
     static let shared = ToastViewModel()
+
+    /// Duration of the toast enter/exit and update animations.
+    private static let animationDuration: TimeInterval = 0.3
+
     var toastWindow: UIWindow?
 
     var isEmpty: Bool { toasts.isEmpty }
@@ -61,7 +65,7 @@ class ToastViewModel: ObservableObject {
             existing.config = config
         }
         Task {
-            try? await Task.sleep(nanoseconds: 300_000_000)
+            try? await Task.sleep(nanoseconds: UInt64(Self.animationDuration * 1_000_000_000))
             existing.isUpdating = false
         }
     }
@@ -106,7 +110,7 @@ class ToastViewModel: ObservableObject {
     }
 
     private func cleanWindow() {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.animationDuration) {
             guard self.isEmpty else { return }
             self.toastWindow?.isHidden = true
             self.toastWindow?.rootViewController = nil


### PR DESCRIPTION
## What this PR does

Milestone 1 of the v2 roadmap — pays down timer/lifecycle tech debt across both
platforms. All non-breaking.

## Changes (iOS + Android)
- **perf (O1):** replace the 10 Hz countdown busy-loop with an event-driven
  deadline that sleeps the full remaining duration and only wakes on a pause
  event. No more per-toast 100 ms wakeups.
- **fix (O2, iOS):** store & cancel the per-toast countdown task on dismiss/update
  (previously it ran to completion after a manual dismiss).
- **fix (O4, Android):** honor hold-to-pause in the countdown — the loop now
  respects pauseMap, matching iOS.
- **fix (O3, Android):** reuse the object-level coroutine scope in
  checkAndRemoveContainer instead of an orphan scope.
- **chore (O5/O7):** remove a leftover debug log; extract the 300 ms animation
  timing into named constants.

## How to test
Verified on a physical device via the redesigned example app (Playground +
Showcase, PR #2):
- [x] auto-dismiss respects duration
- [x] press-and-hold pauses the timer (iOS + Android)
- [x] manual dismiss cancels the countdown (no late dismissal)
- [x] showToastPromise loading → success/error in place

## Breaking changes
None.