### PR TITLE
chore: ignore build output (lib, nitrogen) in eslint config

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,8 @@
 import { defineConfig } from 'eslint/config'
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended'
 
-export default defineConfig([eslintPluginPrettierRecommended])
+export default defineConfig([
+  // Generated / build output — never lint these.
+  { ignores: ['lib/**', 'nitrogen/**', 'node_modules/**'] },
+  eslintPluginPrettierRecommended,
+])


### PR DESCRIPTION
## What this PR does

Fixes the CI Lint step failing on generated files. `eslint.config.mjs` (flat
config) declared no `ignores`, so the legacy `eslintIgnore` in package.json was
not honored. Because `bun install` runs the `prepare` lifecycle (bob build),
`lib/` exists by the time CI lints — so eslint flagged ~80 prettier errors in
generated output and failed the build.

## Changes
- **Tooling:** `eslint.config.mjs` now ignores `lib/**`, `nitrogen/**`, `node_modules/**`.

## How to test
- `bun run prepare` (build lib) then `bun run lint:ci` → passes (verified locally).
- This PR's own CI run should be green.

## Breaking changes
None. Completes the CI hardening from the I1 workflow.