### PR TITLE
chore: infra & internal polish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ permissions:
 
 jobs:
   check:
-    name: Typecheck, lint & build
+    name: Typecheck, lint, test & build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -29,6 +29,9 @@ jobs:
 
       - name: Lint
         run: bun run lint:ci
+
+      - name: Test
+        run: bun run test
 
       - name: Build (bob)
         run: bun run prepare

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,27 +4,39 @@ on:
   push:
     tags:
       - 'v*.*.*' # Runs only when a tag like v1.2.3 is pushed
-  
+
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Use Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
-      - name: Install dependencies with Bun
-        run: bun install
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
 
-      - name: Publish to npm using JS-DevTools/npm-publish
+      # Verify the exact tagged commit before publishing — fail fast on a broken build.
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Lint
+        run: bun run lint:ci
+
+      - name: Build
+        run: bun run prepare
+
+      # NPM_TOKEN must be an npm Automation token with publish access.
+      # (A read-only or expired token fails publish with a misleading 404.)
+      - name: Publish to npm
         uses: JS-DevTools/npm-publish@v3
         with:
           token: ${{ secrets.NPM_TOKEN }}
           access: public
-      
+
       - name: End message
         run: echo "🎉 Released!"

--- a/.release-it.json
+++ b/.release-it.json
@@ -3,10 +3,10 @@
   "git": {
     "commitMessage": "chore(release): v${version}",
     "tagName": "v${version}",
-    "requireCleanWorkingDir": false
+    "requireCleanWorkingDir": true
   },
   "hooks":{
-    "before:init": ["git pull", "bun run lint"],
+    "before:init": ["git pull", "bun run lint:ci"],
     "after:bump": ["bunx auto-changelog -p"]
   },
   "github": {

--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ Check out the [stacked presentation guide](./docs/stacked.md) for more info.
 
 See the [INSTALLATION.md](./docs/INSTALLATION.md) guide for full setup, requirements, and platform instructions.
 
+## ✅ Compatibility
+
+| | Requirement |
+|---|---|
+| React Native | **>= 0.78** |
+| React | >= 18 |
+| `react-native-nitro-modules` | >= 0.35 |
+| **New Architecture** | **Required** |
+| iOS | >= 15.1 (follows React Native's minimum) · visionOS 1.0 |
+| Android | `minSdk` 23 |
+
+> Built on [Nitro Modules](https://nitro.margelo.com), which require React Native's
+> **New Architecture**. The legacy bridge (old architecture) is not supported.
+
 ## 🔧 Quick Start
 
 Check out the [example app](./example) for a full working demo.

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+type ShowCall = { message: string; config: Record<string, unknown> }
+
+let showCalls: ShowCall[] = []
+let dismissCalls: string[] = []
+let idCounter = 0
+
+const fakeModule = {
+  show(message: string, config: Record<string, unknown>) {
+    showCalls.push({ message, config })
+    return `id-${++idCounter}`
+  },
+  dismiss(id: string) {
+    dismissCalls.push(id)
+  },
+}
+
+// index.ts calls createHybridObject at load time — register the mock first.
+mock.module('react-native-nitro-modules', () => ({
+  NitroModules: { createHybridObject: () => fakeModule },
+}))
+
+const { showToast, dismissToast, showToastPromise, defaultToastConfig } =
+  await import('../src/index')
+
+beforeEach(() => {
+  showCalls = []
+  dismissCalls = []
+  idCounter = 0
+})
+
+describe('showToast', () => {
+  test('merges defaults from defaultToastConfig', () => {
+    showToast('hello')
+    expect(showCalls).toHaveLength(1)
+    expect(showCalls[0]!.message).toBe('hello')
+    expect(showCalls[0]!.config).toMatchObject(defaultToastConfig)
+  })
+
+  test('caller config overrides defaults', () => {
+    showToast('x', { position: 'top', type: 'success' })
+    expect(showCalls[0]!.config.position).toBe('top')
+    expect(showCalls[0]!.config.type).toBe('success')
+  })
+
+  test('loading type defaults duration to 0 (sticky)', () => {
+    showToast('x', { type: 'loading' })
+    expect(showCalls[0]!.config.duration).toBe(0)
+  })
+
+  test('explicit duration wins for loading', () => {
+    showToast('x', { type: 'loading', duration: 1500 })
+    expect(showCalls[0]!.config.duration).toBe(1500)
+  })
+
+  test('non-loading keeps the default duration', () => {
+    showToast('x', { type: 'success' })
+    expect(showCalls[0]!.config.duration).toBe(defaultToastConfig.duration)
+  })
+
+  test('returns the native toast id', () => {
+    expect(showToast('x')).toBe('id-1')
+  })
+})
+
+describe('dismissToast', () => {
+  test('forwards the id to native dismiss', () => {
+    dismissToast('abc')
+    expect(dismissCalls).toEqual(['abc'])
+  })
+})
+
+describe('showToastPromise', () => {
+  test('loading then success, reusing the toast id; resolves the value', async () => {
+    const result = await showToastPromise(
+      Promise.resolve({ message: 'done' }),
+      { loading: 'loading…', success: (r) => r.message, error: 'err' },
+      { position: 'top' }
+    )
+    expect(result).toEqual({ message: 'done' })
+    expect(showCalls).toHaveLength(2)
+    expect(showCalls[0]!.config.type).toBe('loading')
+    expect(showCalls[1]!.config.type).toBe('success')
+    expect(showCalls[1]!.message).toBe('done')
+    expect(showCalls[1]!.config.toastId).toBe('id-1')
+  })
+
+  test('shows error and rejects on failure', async () => {
+    await expect(
+      showToastPromise(
+        Promise.reject(new Error('boom')),
+        { loading: 'loading…', success: 'ok', error: (e) => (e as Error).message },
+        {}
+      )
+    ).rejects.toThrow('boom')
+    expect(showCalls[1]!.config.type).toBe('error')
+    expect(showCalls[1]!.message).toBe('boom')
+  })
+
+  test('accepts a promise-returning function', async () => {
+    const result = await showToastPromise(
+      () => Promise.resolve('v'),
+      { loading: 'l', success: (r) => String(r), error: 'e' },
+      {}
+    )
+    expect(result).toBe('v')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -78,8 +78,8 @@
     "typescript": "^5.5.4"
   },
   "peerDependencies": {
-    "react": "*",
-    "react-native": "*",
+    "react": ">=18.0.0",
+    "react-native": ">=0.78.0",
     "react-native-nitro-modules": ">=0.35.0"
   },
   "eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "ios/**/*.cpp",
     "ios/**/*.swift",
     "ios/Assets.xcassets",
-    "app.plugin.js",
     "*.podspec",
     "README.md"
   ],
@@ -38,7 +37,7 @@
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint:ci": "eslint \"**/*.{js,ts,tsx}\"",
     "typescript": "tsc",
-    "specs": "typescript && nitro-codegen --logLevel=\"debug\"",
+    "specs": "tsc && nitro-codegen --logLevel=\"debug\"",
     "release": "release-it",
     "prepare": "bob build"
   },

--- a/package.json
+++ b/package.json
@@ -54,6 +54,9 @@
   },
   "author": "Kiet Huynh <kiethuynh0904@gmail.com> (https://github.com/kiethuynh0904)",
   "license": "MIT",
+  "engines": {
+    "node": ">=18"
+  },
   "bugs": {
     "url": "https://github.com/kiethuynh0904/react-native-nitro-toast/issues"
   },

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "clean": "rm -rf android/build node_modules/**/android/build lib",
     "lint": "eslint \"**/*.{js,ts,tsx}\" --fix",
     "lint:ci": "eslint \"**/*.{js,ts,tsx}\"",
+    "test": "bun test __tests__/*.test.ts",
     "typescript": "tsc",
     "specs": "tsc && nitro-codegen --logLevel=\"debug\"",
     "release": "release-it",


### PR DESCRIPTION
## What this PR does
Infra/internal hardening. No user-facing runtime API change → patch (v1.3.3).

## Changes
-  package.json: drop phantom `app.plugin.js` from `files`; fix `specs` (`typescript &&` → `tsc &&`).
-  tighten `peerDependencies`: `react >=18`, `react-native >=0.78` (was `*`).
-  harden release.yml: typecheck/lint:ci/build before publish; bump `checkout@v4`/`setup-bun@v2`; `--frozen-lockfile`; note Automation-token requirement.
-  release hygiene: `.release-it.json` `requireCleanWorkingDir:true` + hook lint→lint:ci; `engines` (node ≥18). *(Android Java 17 & npm provenance deferred.)*
-  README compatibility matrix.
-  JS unit tests (bun:test) for `showToast`/`dismissToast`/`showToastPromise`; wired into CI.

## How to test
CI runs typecheck + lint:ci + test + build. Tests: `bun run test` (10 pass).

## Breaking changes
None. (peerDeps tightening only emits peer warnings, not install failures.)