### PR TITLE
feat: Android stacked-mode parity with iOS (+ maxWidth fix)

### DIFF
--- a/android/src/main/java/com/margelo/nitro/nitrotoast/DraggableToast.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/DraggableToast.kt
@@ -36,6 +36,7 @@ fun draggableToast(
     position: Alignment,
     onPaused: (Boolean) -> Unit,
     onDismiss: () -> Unit,
+    content: @Composable () -> Unit = { toastView(toast) },
 ) {
     var offsetY by remember { mutableFloatStateOf(0f) }
     val animatedOffsetY by animateFloatAsState(
@@ -94,7 +95,7 @@ fun draggableToast(
                         )
                     }.graphicsLayer(scaleX = scale, scaleY = scale),
         ) {
-            toastView(toast)
+            content()
         }
     }
 }

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastList.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastList.kt
@@ -171,7 +171,11 @@ fun stackedToastList(state: ToastListState) {
                                 position = Alignment.BottomCenter,
                                 onPaused = { state.setPaused(toast.id, it) },
                                 onDismiss = { ToastManager.dismiss(toast.id) },
-                            )
+                            ) {
+                                stackedToastCard(toast) {
+                                    ToastManager.dismiss(toast.id)
+                                }
+                            }
                         }
                     }
                 }

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastList.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastList.kt
@@ -1,12 +1,17 @@
 package com.margelo.nitro.nitrotoast
 
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBars
 import androidx.compose.runtime.Composable
@@ -15,6 +20,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 
 @Composable
@@ -22,6 +30,12 @@ fun toastList(state: ToastListState) {
     val toasts by state.toasts.collectAsState()
 
     if (toasts.isEmpty()) return
+
+    // Stacked presentation: collapsed deck that expands on tap (parity with iOS).
+    if (toasts.firstOrNull()?.config?.presentation == PresentationToastType.STACKED) {
+        stackedToastList(state)
+        return
+    }
 
     val position =
         when (toasts.firstOrNull()?.config?.position) {
@@ -71,6 +85,102 @@ fun toastList(state: ToastListState) {
 
         if (position == Alignment.TopCenter) {
             Spacer(modifier = Modifier.weight(1f))
+        }
+    }
+}
+
+/**
+ * Stacked presentation: a bottom-anchored deck. Collapsed, the newest toast sits in
+ * front and older ones peek scaled-down behind it; tapping expands into a vertical
+ * list (with a dim scrim). Mirrors iOS `ToastStackView`. Blur backdrop is API 31+ only,
+ * so a dim scrim is used for parity across versions.
+ */
+@Composable
+fun stackedToastList(state: ToastListState) {
+    val toasts by state.toasts.collectAsState()
+    val isExpanded by state.isExpanded.collectAsState()
+
+    if (toasts.isEmpty()) return
+
+    val offset = (toasts.firstOrNull()?.config?.offset ?: 0.0).dp
+    val scrimAlpha by animateFloatAsState(
+        targetValue = if (isExpanded) 0.25f else 0f,
+        label = "scrim",
+    )
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        // Dim backdrop while expanded; tap to collapse.
+        if (scrimAlpha > 0f) {
+            Box(
+                modifier =
+                    Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = scrimAlpha))
+                        .pointerInput(Unit) {
+                            detectTapGestures { state.setExpanded(false) }
+                        },
+            )
+        }
+
+        Box(
+            modifier =
+                Modifier
+                    .align(Alignment.BottomCenter)
+                    .navigationBarsPadding()
+                    .padding(bottom = 16.dp + offset),
+            contentAlignment = Alignment.BottomCenter,
+        ) {
+            if (isExpanded) {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(10.dp),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                ) {
+                    toasts.forEach { toast ->
+                        key(toast.id) {
+                            draggableToast(
+                                toast = toast,
+                                position = Alignment.BottomCenter,
+                                onPaused = { state.setPaused(toast.id, it) },
+                                onDismiss = { ToastManager.dismiss(toast.id) },
+                            )
+                        }
+                    }
+                }
+            } else {
+                // Collapsed deck — tap anywhere on it to expand.
+                Box(
+                    modifier =
+                        Modifier.pointerInput(Unit) {
+                            detectTapGestures { state.setExpanded(true) }
+                        },
+                    contentAlignment = Alignment.BottomCenter,
+                ) {
+                    toasts.forEachIndexed { index, toast ->
+                        // depth 0 = newest (front), larger depth = further back.
+                        val depth = (toasts.lastIndex - index).coerceAtMost(2)
+                        val scale by animateFloatAsState(
+                            targetValue = 1f - depth * 0.06f,
+                            label = "deckScale",
+                        )
+                        val translateY by animateFloatAsState(
+                            targetValue = -depth * 14f,
+                            label = "deckOffset",
+                        )
+                        key(toast.id) {
+                            Box(
+                                modifier =
+                                    Modifier.graphicsLayer {
+                                        scaleX = scale
+                                        scaleY = scale
+                                        translationY = translateY
+                                    },
+                            ) {
+                                toastView(toast)
+                            }
+                        }
+                    }
+                }
+            }
         }
     }
 }

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastList.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastList.kt
@@ -1,6 +1,9 @@
 package com.margelo.nitro.nitrotoast
 
+import androidx.compose.animation.core.Spring
+import androidx.compose.animation.core.animateDpAsState
 import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.spring
 import androidx.compose.foundation.background
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -107,6 +110,11 @@ fun stackedToastList(state: ToastListState) {
         targetValue = if (isExpanded) 0.25f else 0f,
         label = "scrim",
     )
+    val spacing by animateDpAsState(
+        targetValue = if (isExpanded) 10.dp else (-40).dp,
+        animationSpec = spring(stiffness = Spring.StiffnessMediumLow),
+        label = "spacing",
+    )
 
     Box(modifier = Modifier.fillMaxSize()) {
         // Dim backdrop while expanded; tap to collapse.
@@ -122,61 +130,48 @@ fun stackedToastList(state: ToastListState) {
             )
         }
 
+        // Single column for both states — animating spacing (overlap when collapsed)
+        // + per-toast scale gives a smooth deck <-> list morph (no layout swap).
         Box(
             modifier =
                 Modifier
                     .align(Alignment.BottomCenter)
                     .navigationBarsPadding()
-                    .padding(bottom = 16.dp + offset),
+                    .padding(bottom = 16.dp + offset)
+                    .pointerInput(Unit) {
+                        detectTapGestures { state.setExpanded(!state.isExpanded.value) }
+                    },
             contentAlignment = Alignment.BottomCenter,
         ) {
-            if (isExpanded) {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(10.dp),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                ) {
-                    toasts.forEach { toast ->
-                        key(toast.id) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(spacing),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                toasts.forEachIndexed { index, toast ->
+                    val depth = (toasts.lastIndex - index).coerceAtMost(2)
+                    val scale by animateFloatAsState(
+                        targetValue = if (isExpanded) 1f else 1f - depth * 0.05f,
+                        animationSpec =
+                            spring(
+                                dampingRatio = Spring.DampingRatioLowBouncy,
+                                stiffness = Spring.StiffnessLow,
+                            ),
+                        label = "deckScale",
+                    )
+                    key(toast.id) {
+                        Box(
+                            modifier =
+                                Modifier.graphicsLayer {
+                                    scaleX = scale
+                                    scaleY = scale
+                                },
+                        ) {
                             draggableToast(
                                 toast = toast,
                                 position = Alignment.BottomCenter,
                                 onPaused = { state.setPaused(toast.id, it) },
                                 onDismiss = { ToastManager.dismiss(toast.id) },
                             )
-                        }
-                    }
-                }
-            } else {
-                // Collapsed deck — tap anywhere on it to expand.
-                Box(
-                    modifier =
-                        Modifier.pointerInput(Unit) {
-                            detectTapGestures { state.setExpanded(true) }
-                        },
-                    contentAlignment = Alignment.BottomCenter,
-                ) {
-                    toasts.forEachIndexed { index, toast ->
-                        // depth 0 = newest (front), larger depth = further back.
-                        val depth = (toasts.lastIndex - index).coerceAtMost(2)
-                        val scale by animateFloatAsState(
-                            targetValue = 1f - depth * 0.06f,
-                            label = "deckScale",
-                        )
-                        val translateY by animateFloatAsState(
-                            targetValue = -depth * 14f,
-                            label = "deckOffset",
-                        )
-                        key(toast.id) {
-                            Box(
-                                modifier =
-                                    Modifier.graphicsLayer {
-                                        scaleX = scale
-                                        scaleY = scale
-                                        translationY = translateY
-                                    },
-                            ) {
-                                toastView(toast)
-                            }
                         }
                     }
                 }

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
@@ -32,6 +32,13 @@ class ToastListState {
     private val _pauseMap = MutableStateFlow<Map<String, Boolean>>(emptyMap())
     val pauseMap = _pauseMap.asStateFlow()
 
+    private val _isExpanded = MutableStateFlow(false)
+    val isExpanded = _isExpanded.asStateFlow()
+
+    fun setExpanded(expanded: Boolean) {
+        _isExpanded.value = expanded
+    }
+
     fun setPaused(
         toastId: String,
         paused: Boolean,
@@ -81,12 +88,14 @@ class ToastListState {
         updateVisibility(toastId, false)
         delay(ANIMATION_DURATION_MS)
         _toasts.value = _toasts.value.filterNot { it.id == toastId }
+        if (_toasts.value.isEmpty()) _isExpanded.value = false
     }
 
     suspend fun clearWithAnimation() {
         _toasts.value = _toasts.value.map { it.copy(isVisible = false) }
         delay(ANIMATION_DURATION_MS)
         _toasts.value = emptyList()
+        _isExpanded.value = false
     }
 }
 

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastManager.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeoutOrNull
@@ -228,14 +229,18 @@ object ToastManager {
 
         if (duration > 0) {
             var remaining = duration.toLong() - ANIMATION_DURATION_MS
+            // Paused while held (pauseMap) OR while the stacked deck is expanded (iOS parity).
+            val paused =
+                combine(state.pauseMap, state.isExpanded) { pm, expanded ->
+                    pm[toast.id] == true || expanded
+                }
             while (remaining > 0) {
-                // Suspend (no polling) until the toast is not paused.
-                state.pauseMap.first { it[toast.id] != true }
+                paused.first { !it } // suspend until not paused (no polling)
                 val start = SystemClock.elapsedRealtime()
-                // Sleep for the remaining time, waking early only if it becomes paused.
+                // Sleep the remaining time, waking early if it becomes paused.
                 val becamePaused =
                     withTimeoutOrNull(remaining) {
-                        state.pauseMap.first { it[toast.id] == true }
+                        paused.first { it }
                         true
                     }
                 if (becamePaused == null) {

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastView.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastView.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -25,6 +26,8 @@ import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicText
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -121,6 +124,65 @@ fun toastView(toast: Toast) {
                     )
                 }
             }
+        }
+    }
+}
+
+/**
+ * Stacked-mode card: neutral surface, type icon + message, and an X to dismiss.
+ * Mirrors the iOS stacked toast (no type-colored background, no title).
+ */
+@Composable
+fun stackedToastCard(
+    toast: Toast,
+    onDismiss: () -> Unit,
+) {
+    val context = LocalContext.current
+    Box(
+        modifier =
+            Modifier
+                .widthIn(max = toast.config.maxWidth?.dp ?: MAX_TOAST_WIDTH)
+                .fillMaxWidth()
+                .padding(horizontal = 15.dp)
+                .shadow(2.dp, RoundedCornerShape(28.dp))
+                .background(Color.White, RoundedCornerShape(28.dp)),
+    ) {
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.padding(vertical = 12.dp, horizontal = 15.dp),
+        ) {
+            renderToastIcon(toast)
+
+            Spacer(modifier = Modifier.width(12.dp))
+
+            BasicText(
+                text = toast.message,
+                modifier = Modifier.weight(1f),
+                style =
+                    TextStyle(
+                        fontSize = 13.sp,
+                        color = Color(0xFF11141A),
+                        fontFamily =
+                            resolveFontFamilyFromReact(
+                                context,
+                                toast.config.fontFamily,
+                                android.graphics.Typeface.NORMAL,
+                            ),
+                    ),
+            )
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            Image(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "Dismiss",
+                colorFilter = ColorFilter.tint(Color(0xFF9AA0AC)),
+                modifier =
+                    Modifier
+                        .size(20.dp)
+                        .clip(CircleShape)
+                        .clickable { onDismiss() },
+            )
         }
     }
 }

--- a/android/src/main/java/com/margelo/nitro/nitrotoast/ToastView.kt
+++ b/android/src/main/java/com/margelo/nitro/nitrotoast/ToastView.kt
@@ -56,8 +56,8 @@ fun toastView(toast: Toast) {
 
     val containerModifier =
         Modifier
-            .fillMaxWidth()
             .widthIn(max = toast.config.maxWidth?.dp ?: MAX_TOAST_WIDTH)
+            .fillMaxWidth()
             .padding(horizontal = 15.dp)
             .shadow(1.5.dp, RoundedCornerShape(12.dp))
             .background(Color.White, RoundedCornerShape(12.dp))

--- a/docs/stacked.md
+++ b/docs/stacked.md
@@ -1,8 +1,10 @@
-# 🍞 Stacked Toast (iOS Only)
+# 🍞 Stacked Toast
 
-> ⚠️ Currently supported only on iOS.
+> Supported on **both iOS and Android**.
 
-The `stacked` presentation queues multiple toasts and displays them one-by-one.
+The `stacked` presentation collects multiple toasts into a deck: the newest sits in
+front with older ones peeking behind it. Tap the deck to expand it into a list (with a
+dim backdrop); tap the backdrop to collapse.
 
 ---
 


### PR DESCRIPTION
## What this PR does
Brings the `stacked` presentation to Android with parity to iOS, plus a maxWidth fix.
Android-only (iOS untouched); no public API change.

## Changes (Android)
- **P1** stacked presentation: `toastList` branches on `presentation`; new
  `stackedToastList` renders a bottom-anchored deck (newest in front, older peeking)
  that expands to a list on tap with a dim scrim. `ToastListState` gains `isExpanded`.
- **Smooth morph**: one Column for both states, animating spacing (overlap when
  collapsed) + per-toast spring scale — no layout swap/re-mount.
- **iOS-matched card**: `stackedToastCard` = neutral surface + type icon + message +
  an **X dismiss button** (no type-colored background/title). `draggableToast` gains a
  content slot so the card keeps swipe + enter/exit.
- **Auto-dismiss pauses while the deck is expanded** (combine `pauseMap` + `isExpanded`),
  matching iOS; respects `duration` (use `0` for sticky).
- **fix:** `maxWidth` was a no-op on Android (`.fillMaxWidth().widthIn` order) — swapped
  so the cap applies. (Bug was in merged T1/T3; fixed here.)
- docs/stacked.md: no longer "iOS only".

## How to test (Android)
Showcase → "Stacked deck": neutral cards with an X, tap to expand/collapse (smooth),
swipe or X to dismiss. Playground: Max width caps on tablet. Compare with iOS.

## Verified
`gradle compileDebugKotlin` succeeds; JS typecheck/lint/test pass. Visual behavior
confirmed on device by maintainer.

## Breaking changes
None.